### PR TITLE
fix form partial

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<% if user.errors.present? %>
+<% if user&.errors.present? %>
   <ul id="error_explanation">
     <% user.errors.full_messages.each do |message| %>
     <li><%= message %></li>


### PR DESCRIPTION
errorが出たさいにuserがnullだとヌルポエラーになるため、エラーが出ないように
<% if user&.errors.present? %>とボッチ関数を使用する形に変更