### PR TITLE
同一ユーザーからの一人のペットシッターへの口コミ制御

### DIFF
--- a/app/controllers/petsitters_controller.rb
+++ b/app/controllers/petsitters_controller.rb
@@ -10,10 +10,20 @@ class PetsittersController < ApplicationController
 
   # ペットシッター詳細表示
   def show
+    # 該当のペットシッターを検索
     @petsitter = Petsitter.find(params[:id])
+
+    # 新規レビュー用インスタンス
     @review = Review.new
+
+    # 該当のペットシッターIDで検索できるレビューを取得
     @reviews = Review.where(petsitter: @petsitter.id)
+
+    # reviewコントローラーなどで使うため@petsitter.idをsessionに保存
     session[:petsitter_id] = @petsitter.id
+
+    # 自分のコメントがあるかチェックする
+    @is_my_review = @reviews.find_by(user_id: current_user.id)
   end
 
   # ペットシッター新規登録ページ表示

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,4 +1,22 @@
 class Review < ApplicationRecord
+  # 書く順番
+  # ①アソシエーション（belongs_toなど）
+  # ②gemなどの関数や他の定義
+  # ③AttributeMethodsモジュール
+  # ④attr関連
+  # ⑤バリデーション
+  # ⑥コールバック
+
   belongs_to :user
   belongs_to :petsitter
+
+  before_save :validate_duplicate_review_by_same_user
+
+
+  private
+    # 一人のユーザーから、同じペットシッターへのレビューセーブはエラーにする
+    # TODO テストをする必要あり（テスト未作成）
+    def validate_duplicate_review_by_same_user
+      # errors.add('同じペットシッターへの2回以上のレビューはできません。') if Review.find_by(user_id: 提出されたreviewのuser_id, petsitter_id: 提出されたreviewのpetsitter_id)
+    end
 end

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,52 +1,56 @@
-<!-- 口コミ入力フォーム -->
-<%= form_with model: review, local: true do |f| %>
+<% unless @is_my_review %>
 
-  <!--エラーメッセージ-->
+  <!-- 口コミ入力フォーム -->
+  <%= form_with model: review, local: true do |f| %>
 
-  <!--ペットシッターIDの送信-->
-  <%= f.hidden_field :petsitter_id, { value: @petsitter.id } %>
+    <!--エラーメッセージ-->
 
-  <!-- タイトル -->
-  <div class="form-group row">
-    <%= f.label :title, class:'col-md-3 col-form-label' %>
-    <div class="col-md-9">
-      <%= f.text_field :title, class: "form-control", id:'review_title', value: review&.title %>
+    <!--ペットシッターIDの送信-->
+    <%= f.hidden_field :petsitter_id, { value: @petsitter.id } %>
+
+    <!-- タイトル -->
+    <div class="form-group row">
+      <%= f.label :title, class:'col-md-3 col-form-label' %>
+      <div class="col-md-9">
+        <%= f.text_field :title, class: "form-control", id:'review_title', value: review&.title %>
+      </div>
     </div>
-  </div>
 
-  <!-- 評価 -->
-  <div class="form-group row" id="star">
-    <%= f.label :rate, class:'col-md-3 col-form-label' %>
-    <%= f.hidden_field :rate, id: :review_star, id:'review_title', value: review&.title %>
-  </div>
-
-  <!-- 評価javascript -->
-  <script>
-      $('#star').raty({
-          size     : 36,
-          starOff:  '<%= asset_path('star-off.png') %>',
-          starOn : '<%= asset_path('star-on.png') %>',
-          starHalf: '<%= asset_path('star-half.png') %>',
-          scoreName: 'review[rate]',
-          half: true,
-          score: <%= review.rate unless review == nil %>
-      });
-  </script>
-
-  <!-- 口コミ -->
-  <div class="form-group row">
-    <%= f.label :content, class:'col-md-3 col-form-label' %>
-    <div class="col-md-9">
-      <%= f.text_area :content, class: "form-control", rows: "8", id:'review_content', value: review&.content,
-                      placeholder:'口コミ内容がなくても、タイトルと評価のみで投稿できます。まずは投稿してみましょう！投稿してから編集もできますよ！' %>
+    <!-- 評価 -->
+    <div class="form-group row" id="star">
+      <%= f.label :rate, class:'col-md-3 col-form-label' %>
+      <%= f.hidden_field :rate, id: :review_star, id:'review_title', value: review&.title %>
     </div>
-  </div>
 
-  <!-- 確認ボタン -->
-  <div class="form-group row justify-content-end">
-    <div class="col-md-9">
-      <%= f.submit '投稿する', class:"btn btn-success" %>
+    <!-- 評価javascript -->
+    <script>
+        $('#star').raty({
+            size     : 36,
+            starOff:  '<%= asset_path('star-off.png') %>',
+            starOn : '<%= asset_path('star-on.png') %>',
+            starHalf: '<%= asset_path('star-half.png') %>',
+            scoreName: 'review[rate]',
+            half: true,
+            score: <%= review.rate unless review == nil %>
+        });
+    </script>
+
+    <!-- 口コミ -->
+    <div class="form-group row">
+      <%= f.label :content, class:'col-md-3 col-form-label' %>
+      <div class="col-md-9">
+        <%= f.text_area :content, class: "form-control", rows: "8", id:'review_content', value: review&.content,
+                        placeholder:'口コミ内容がなくても、タイトルと評価のみで投稿できます。まずは投稿してみましょう！投稿してから編集もできますよ！' %>
+      </div>
     </div>
-  </div>
+
+    <!-- 確認ボタン -->
+    <div class="form-group row justify-content-end">
+      <div class="col-md-9">
+        <%= f.submit '投稿する', class:"btn btn-success" %>
+      </div>
+    </div>
+
+  <% end %>
 
 <% end %>

--- a/app/views/reviews/_show-reviews.html.erb
+++ b/app/views/reviews/_show-reviews.html.erb
@@ -29,6 +29,7 @@
           <!--/星評価-->
 
           <p><%= review.content %></p>
+          <%#= image_tag @petsitter.image.url, class:'img-fluid' if @petsitter.image? %>
         </div>
       </div>
       <!--      <div class="col-md-4">-->


### PR DESCRIPTION
一人のユーザーから一人のペットシッターへの複数件の口コミができないように修正
ただし、修正箇所はviewでの制御のみになっており、modelでの制御は型はできているが、user_idの指定やpetsitter_idの指定（提出されたreviewインスタンスから引っ張ってきたい）はできていないので、その点は後ほど検討が必要。
また、テストもまだかけていない。