### PR TITLE
注意書き追加

### DIFF
--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -124,4 +124,5 @@
   }
 
 </script>
+<!-- 以下のYOUR_API_KEYには非公開情報を入れるようにする。そのままAPIキーは載せない。 -->
 <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap" async defer></script>


### PR DESCRIPTION
googleAPIキー露出問題については以下のようにして対処
・GooglePlatformのプロジェクト自体を削除（apiキーは一プロジェクト一apiのため、これで不正利用されても意味がなくなった。）
・新しいプロジェクトを作成し、今度はgitignore記載済みのファイルから参照するようにする＋apiキー自体の制限を強めて使用。
以上の点を踏まえて、サンプル部分に注意書きを追加。
